### PR TITLE
fix(simplessh): static inline get_socket function to resolve linker issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .stack-work
+stack.yaml.lock
+Example
+Example.hi
+Example.o

--- a/Example.hs
+++ b/Example.hs
@@ -8,15 +8,20 @@ import Network.SSH.Client.SimpleSSH
 
 action :: FilePath -> String -> String -> SimpleSSH ()
 action home username host = do
-  withSessionKey host 22 (home ++ "/.ssh/known_hosts") username
-                 (home ++ "/.ssh/id_rsa.pub") (home ++ "/.ssh/id_rsa")
-                 "" $ \session -> do
+  withSessionKey
+    host
+    22
+    (home ++ "/.ssh/known_hosts")
+    username
+    (home ++ "/.ssh/id_ed25519.pub")
+    (home ++ "/.ssh/id_ed25519")
+    "" $ \session -> do
     res <- execCommand session "uname -a"
     liftIO $ print res
 
 main :: IO ()
 main = do
-  username : host : _ <- getArgs
+  username:host:_ <- getArgs
   Just home <- lookup "HOME" <$> getEnvironment
   eRes <- runSimpleSSH $ action home username host
   case eRes of

--- a/cbits/simplessh.c
+++ b/cbits/simplessh.c
@@ -46,7 +46,7 @@ static int waitsocket(int socket_fd, LIBSSH2_SESSION *session) {
   return rc;
 }
 
-inline int get_socket(const char *hostname, uint16_t port) {
+int get_socket(const char *hostname, uint16_t port) {
   struct addrinfo hints;
   memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family   = AF_UNSPEC;

--- a/cbits/simplessh.c
+++ b/cbits/simplessh.c
@@ -46,7 +46,7 @@ static int waitsocket(int socket_fd, LIBSSH2_SESSION *session) {
   return rc;
 }
 
-int get_socket(const char *hostname, uint16_t port) {
+static inline int get_socket(const char *hostname, uint16_t port) {
   struct addrinfo hints;
   memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family   = AF_UNSPEC;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.20
+resolver: lts-19.8
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
Hello,

From what I could find online it seems like the some compiler optimizations came along after this project was originally developed that cause a failure to resolve the `get_socket` function in simplessh.c. This change forces the linker to maintain the reference to the function and should maintain the original intent of signaling the function as inline-able.

It addresses this issue here as well. https://github.com/thoferon/simplessh/issues/2

Feel free to adjust the formatting (I just let hindent do the work)